### PR TITLE
Modified the automatad's bidder docs to support prebid server documen…

### DIFF
--- a/dev-docs/bidders/automatad.md
+++ b/dev-docs/bidders/automatad.md
@@ -23,5 +23,8 @@ fpd_supported: false
 {: .table .table-bordered .table-striped }
 | Name          | Scope    | Description | Example | Type     |
 |---------------|----------|-------------|---------|----------|
-| `position` | required | Position field from automatad | `'123'` | `string` |
+| `position` | required | Position field from automatad | `22390678` | `string` |
+| `siteId`    | required | The site ID from automatad.  | `"12adf45c"` | `string` |
+| `placementId`    | optional | The placement ID from automatad.  | `"a34gh6d"` | `string` |
+
 

--- a/dev-docs/bidders/automatad.md
+++ b/dev-docs/bidders/automatad.md
@@ -4,11 +4,12 @@ title: Automatad OpenRTB Bid Adapter
 description: Automatad OpenRTB Bid Adapter
 biddercode: automatad 
 pbjs: true
+pbs: true
 media_types: banner
 fpd_supported: false
 ---
 
-#### Bid Params
+#### Prebid.js Bid Params
 
 {: .table .table-bordered .table-striped }
 
@@ -16,3 +17,11 @@ fpd_supported: false
 |-----------|----------|---------------------------|------------|----------|
 | `siteId`    | required | The site ID from automatad.  | `"12adf45c"` | `string` |
 | `placementId`    | optional | The placement ID from automatad.  | `"a34gh6d"` | `string` |
+
+### Prebid-Server Bid Params
+
+{: .table .table-bordered .table-striped }
+| Name          | Scope    | Description | Example | Type     |
+|---------------|----------|-------------|---------|----------|
+| `position` | required | Position field from automatad | `'123'` | `string` |
+


### PR DESCRIPTION
Automatad has now added support for Prebid Server. This PR is the documentation update for bid params.

## 🏷 Type of documentation

- [✔] new bid adapter
- [ ] update bid adapter
- [ ] new feature
- [ ] text edit only (wording, typos)
- [ ] bugfix (code examples)
- [ ] new examples

